### PR TITLE
Added extra requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,9 +29,9 @@ setuptools.setup(
         "dnaplotlib",
         "biopython",
         "reportlab",
-        "tesbml",
         "nbgitpuller",
         "tellurium",
     ],
+    extras_requirements={'sbml': ['tesbml']}, 
     include_package_data=True,
 )


### PR DESCRIPTION
Hi, I really like your package and I enjoy using it, but I would really like it to support python >3.8. As of now, the tesbml is hindering this, so I added this package as an additional requirement - since there is an ImportError in the file it is used which would be caught by the user. 

If you think this is a good idea, I would also add documentation to this installation step.  Roughly speaking this would include a few lines in the README file indicating that if the user wishes to use the sbmlgen module they have to install the additional packages as such:  pip install synbiopython[all] or pip install synbiopython[tesbml] 

Thanks for supporting the synbio community with this package. I will look forward to your reply. 

Cheers, 
Lucas 